### PR TITLE
Handle case where chatbox is open but input is hidden

### DIFF
--- a/src/main/java/com/chatfade/ChatFadeConfig.java
+++ b/src/main/java/com/chatfade/ChatFadeConfig.java
@@ -237,12 +237,12 @@ public interface ChatFadeConfig extends Config
 
 	@ConfigItem(
 		keyName = "onlyWhenCollapsed",
-		name = "Only When Chatbox Collapsed",
+		name = "Only When Chatbox Hidden",
 		description = "Only show fading messages when the chatbox is hidden/collapsed",
 		position = 31,
 		section = behaviorSection
 	)
-	default boolean onlyWhenCollapsed()
+	default boolean onlyWhenHidden()
 	{
 		return true;
 	}

--- a/src/main/java/com/chatfade/ChatFadeOverlay.java
+++ b/src/main/java/com/chatfade/ChatFadeOverlay.java
@@ -46,16 +46,16 @@ public class ChatFadeOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		boolean collapsed = isChatboxCollapsed();
+		boolean chatboxHidden = isChatboxInputHidden();
 
-		if (config.onlyWhenCollapsed() && !collapsed)
+		if (config.onlyWhenHidden() && !chatboxHidden)
 		{
 			return null;
 		}
 
 		plugin.pruneExpiredMessages();
 
-		String typedText = getTypedText(collapsed);
+		String typedText = getTypedText(chatboxHidden);
 		List<FadingMessage> messages = plugin.getMessages();
 
 		if (messages.isEmpty() && typedText == null)
@@ -265,6 +265,16 @@ public class ChatFadeOverlay extends Overlay
 	}
 
 	private boolean isChatboxCollapsed()
+	{
+		Widget chatArea = client.getWidget(InterfaceID.Chatbox.CHATAREA);
+		if (chatArea == null)
+		{
+			return true;
+		}
+		return chatArea.isHidden();
+	}
+
+	private boolean isChatboxInputHidden()
 	{
 		Widget chatboxInput = client.getWidget(InterfaceID.Chatbox.INPUT);
 		if (chatboxInput == null)


### PR DESCRIPTION
Current dev branch behaviour:

![java_nfPfwvOCaA](https://github.com/user-attachments/assets/e52d3ff7-2fdc-4b9d-b700-5059f038525b)

This PR's behaviour:

![java_OoiQlKeGCA](https://github.com/user-attachments/assets/f1b9d5a0-1ff0-4848-84bb-a0abc5310ead)

A simpler solution would be to just do the same chatArea check everywhere, instead of separate chatArea and chatboxInput checks, but I actually really like being able to see the Chat Fade overlay when I'm in quest dialogue or a crafting UI, despite being set to Only When Collapsed/Hidden.

(It may also be nice to have configs for separate chat types shown depending on if chat is hidden or not. Ie *always* show Private Chat in the overlay, but only show General/Public/Clan/etc when chat is hidden. But that's a PR for another day).