### PR TITLE
Modify regex for Combat Achievements

### DIFF
--- a/src/main/java/com/chatfade/ChatFadePlugin.java
+++ b/src/main/java/com/chatfade/ChatFadePlugin.java
@@ -74,7 +74,7 @@ public class ChatFadePlugin extends Plugin
 
 		// Combat Achievement clan messages include a "CA_ID:###" prefix used for
 		// icon lookup — strip it so only the human-readable text is shown.
-		cleanedText = cleanedText.replaceFirst("^CA_ID:\\d+", "").trim();
+		cleanedText = cleanedText.replaceFirst("^CA_ID:\\d+\\s*\\|?", "").trim();
 
 		String sender = chatMessage.getName();
 		if (sender != null && !sender.isEmpty())


### PR DESCRIPTION
Currently the regex for Combat Achievements leaves a stray `|` symbol at the beginning of the message; this modification removes that symbol.