### PR TITLE
Prevent displaying caret and adjusting chat height if `Show Typing Input` is disabled

### DIFF
--- a/src/main/java/com/chatfade/ChatFadeOverlay.java
+++ b/src/main/java/com/chatfade/ChatFadeOverlay.java
@@ -31,6 +31,8 @@ public class ChatFadeOverlay extends Overlay
 	private final ChatFadePlugin plugin;
 	private final ChatFadeConfig config;
 
+	private boolean keyRemapping = false;
+
 	@Inject
 	public ChatFadeOverlay(Client client, ChatFadePlugin plugin, ChatFadeConfig config)
 	{
@@ -58,7 +60,7 @@ public class ChatFadeOverlay extends Overlay
 		String typedText = getTypedText(chatboxHidden);
 		List<FadingMessage> messages = plugin.getMessages();
 
-		if (messages.isEmpty() && typedText == null)
+		if (messages.isEmpty() && typedText == null && !chatInputEnabled())
 		{
 			return null;
 		}
@@ -72,7 +74,7 @@ public class ChatFadeOverlay extends Overlay
 
 		FontMetrics fm = graphics.getFontMetrics();
 		int lineHeight = fm.getHeight();
-		boolean hasTypingLine = typedText != null;
+		boolean hasTypingLine = (keyRemapping && chatInputEnabled()) || typedText != null;
 
 		int baseY = calculateBaseY(lineHeight, messages.size(), hasTypingLine) + config.yOffset();
 		int baseX = PADDING_LEFT + config.xOffset();
@@ -418,7 +420,28 @@ public class ChatFadeOverlay extends Overlay
 		{
 			return true;
 		}
+
+		if(chatboxInput.getText().contains("Press Enter to Chat...")){
+			keyRemapping = true;
+		}
+
 		return chatboxInput.isHidden();
+	}
+
+	private boolean chatInputEnabled()
+	{
+		Widget chatboxInput = client.getWidget(InterfaceID.Chatbox.INPUT);
+		if (chatboxInput == null)
+		{
+			return false;
+		}
+
+		if(chatboxInput.getText().contains("Press Enter to Chat...")){
+			keyRemapping = true;
+			return false;
+		}
+
+		return true;
 	}
 
 	private static Color withAlpha(Color color, float alpha)

--- a/src/main/java/com/chatfade/ChatFadeOverlay.java
+++ b/src/main/java/com/chatfade/ChatFadeOverlay.java
@@ -81,7 +81,7 @@ public class ChatFadeOverlay extends Overlay
 		int lineHeight = fm.getHeight();
 		boolean hasTypingLine = (keyRemapping && chatInputEnabled()) || typedText != null;
 
-		int baseY = calculateBaseY(lineHeight, messages.size(), hasTypingLine) + config.yOffset();
+		int baseY = calculateBaseY(lineHeight, messages.size(), (config.showTypingInput() && hasTypingLine)) + config.yOffset();
 		int baseX = PADDING_LEFT + config.xOffset();
 
 		long now = System.currentTimeMillis();
@@ -119,7 +119,7 @@ public class ChatFadeOverlay extends Overlay
 		}
 
 		// Render typing input line
-		if (hasTypingLine)
+		if (hasTypingLine && config.showTypingInput())
 		{
 			graphics.setComposite(originalComposite);
 

--- a/src/main/java/com/chatfade/ChatFadeOverlay.java
+++ b/src/main/java/com/chatfade/ChatFadeOverlay.java
@@ -31,8 +31,6 @@ public class ChatFadeOverlay extends Overlay
 	private final ChatFadePlugin plugin;
 	private final ChatFadeConfig config;
 
-	private boolean keyRemapping = false;
-
 	@Inject
 	public ChatFadeOverlay(Client client, ChatFadePlugin plugin, ChatFadeConfig config)
 	{
@@ -60,7 +58,7 @@ public class ChatFadeOverlay extends Overlay
 		String typedText = getTypedText(chatboxHidden);
 		List<FadingMessage> messages = plugin.getMessages();
 
-		if (messages.isEmpty() && typedText == null && !chatInputEnabled())
+		if (messages.isEmpty() && typedText == null)
 		{
 			return null;
 		}
@@ -74,7 +72,7 @@ public class ChatFadeOverlay extends Overlay
 
 		FontMetrics fm = graphics.getFontMetrics();
 		int lineHeight = fm.getHeight();
-		boolean hasTypingLine = (keyRemapping && chatInputEnabled()) || typedText != null;
+		boolean hasTypingLine = typedText != null;
 
 		int baseY = calculateBaseY(lineHeight, messages.size(), hasTypingLine) + config.yOffset();
 		int baseX = PADDING_LEFT + config.xOffset();
@@ -420,28 +418,7 @@ public class ChatFadeOverlay extends Overlay
 		{
 			return true;
 		}
-
-		if(chatboxInput.getText().contains("Press Enter to Chat...")){
-			keyRemapping = true;
-		}
-
 		return chatboxInput.isHidden();
-	}
-
-	private boolean chatInputEnabled()
-	{
-		Widget chatboxInput = client.getWidget(InterfaceID.Chatbox.INPUT);
-		if (chatboxInput == null)
-		{
-			return false;
-		}
-
-		if(chatboxInput.getText().contains("Press Enter to Chat...")){
-			keyRemapping = true;
-			return false;
-		}
-
-		return true;
 	}
 
 	private static Color withAlpha(Color color, float alpha)

--- a/src/main/java/com/chatfade/ChatFadePlugin.java
+++ b/src/main/java/com/chatfade/ChatFadePlugin.java
@@ -753,7 +753,6 @@ public class ChatFadePlugin extends Plugin implements KeyListener
 			case ENGINE:
 			case SPAM:
 			case WELCOME:
-			case LOGINLOGOUTNOTIFICATION:
 			case FRIENDNOTIFICATION:
 			case IGNORENOTIFICATION:
 			case CONSOLE:
@@ -768,6 +767,7 @@ public class ChatFadePlugin extends Plugin implements KeyListener
 			case PRIVATECHAT:
 			case MODPRIVATECHAT:
 			case PRIVATECHATOUT:
+			case LOGINLOGOUTNOTIFICATION:
 				return config.showPrivateChat();
 
 			case CLAN_CHAT:


### PR DESCRIPTION
All of the commits besides the last one were already merged; you can squash those so that it doesn't muddy the commit log